### PR TITLE
bitdevs: add covenant discussion topics

### DIFF
--- a/_posts/2024-01-09-socratic-seminar-11.md
+++ b/_posts/2024-01-09-socratic-seminar-11.md
@@ -43,6 +43,35 @@ This meetup will be run in the format of a Socratic Seminar, inspired by other [
  - [Altruistic Rebroadcasting - A Partial Replacement Cycling Mitigation](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2023-December/022188.html)
  - [2023 Node Performance Tests](https://archive.ph/QCgOr)
 
+## Covenant Discusssion
+
+- Reactive Security (ie: eliminate threat of key theft). This has added benefit that backups become less cumbersome. Requires 2 TX to fully unencumber coins in base use case.
+
+### OP_CTV
+- [BIP 119](https://github.com/bitcoin/bips/blob/master/bip-0119.mediawiki)
+- [Simple CTV Vault](https://github.com/jamesob/simple-ctv-vault)
+    - How does a pure OP_CTV vault compare to an OP_VAULT vault?
+
+### OP_VAULT
+- [BIP 345](https://github.com/bitcoin/bips/blob/de9ef59307f5d94883eefd2c6691c67d358d915a/bip-0345.mediawiki)
+- [On the unsuitability of pre-signed transactions](https://delvingbitcoin.org/t/the-unsuitability-of-presigned-transactions-for-vaults/113)
+- [On the benefit with OP_CTV](https://x.com/jamesob/status/1742375641641574896?s=20)
+- [OP_VAULT Demo](https://www.youtube.com/watch?v=7Zwm5iHFyBQ)
+
+- What is the purpose of the CTV in the time-locked CTV tapleaf of a trigger transaction? The necessity of the timelock is clear, but what advantage does CTV offer in this context over plain OP_CHECKSIGVERIFY?
+
+"dynamic unvault targets, which allow the proposed withdrawal target for a vault to be specified at withdrawal time rather than when the vault is first created. This would remove the need for a prespecified, intermediate wallet that only exists to route unvaulted funds to their desired destination."
+
+"These tapleaf replacement rules, described more precisely below, ensure a timelocked withdrawal, where the timelock is fixed by the original OP_VAULT parameters, to a fixed set of outputs (via OP_CHECKTEMPLATEVERIFY[2]) which is chosen when the withdrawal process is triggered."
+"During the withdrawal process, the proposed final destination for value being withdrawn must be committed to."
+- Who cares that withdrawal commits to a fixed set of outputs? OP_VAULT is already a covenant. Why do we need the nested CTV covenant?
+
+- How does the OP_VAULT opcode check that the output being created by the trigger transaction consist of the exact same taptree with only the OP_VAULT leaf substituted for the templated time-locked leaf script?
+The taproot "control block" consists of all the data necessary to evaluate taproot spends. This consists of a tapleaf script being spent, alond with a merkle path from that leaf to the taptree root. The opcode can simply replace the executing leaf with the new leaf, recompute a taptree root and verify that this root matches + internal key matches the created output's script public key. The address will not specify it's taptree root. Isn't that information only provided at spend time? If the internal key is the same then we can check that our computed taptree root post-substitution + internal key yields the same raw public key.
+
+Via a *single* taptree leaf replacement mechanism, the OP_VAULT opcode enforces that the transaction which spends from our vault does NOT contain ANY new spending conditions EXCEPT for a pre-committed template script leaf which will replace the OP_VAULT script leaf. This ensures that any vault withdrawal moves to an intermediate staging output with no degredation in security and which is time-locked so that we may have time to respond to un-authorized vault withdrawals. It carries forward our recovery script leaf and enforces that the other leaf will be exactly as templated.
+
+
 # Fedimint
  - [Fedimint 0.2.1 Federate all the Things](https://github.com/fedimint/fedimint/releases/tag/v0.2.1)
  - [Awesome Fedimint](https://github.com/fedimint/awesome-fedimint)


### PR DESCRIPTION
Working on prepping some discussion for Covenants. Might not quite have it there in time for January meeting, but we could give it a shot anyway 🤷‍♂️ 

A possible approach to discussion could be:
1. Quick overview of basic transaction structure (so people know what an output is)
2. Covenants w/ pre-signed transactions (and the problems with this approach)
3. Explore CTV and OP_VAULT from the perspective of what restrictions they put on outputs.
    1. Script opcode which requires that the output created by the spending transaction is of a particular structure. The taproot script tree must remain unchanged EXCEPT for a single leaf change which begins the time-locked unvault trigger transaction. NOTE: I still have some questions here myself.
    1. Highlight that OP_VAULT does not require CTV, though it does benefit from it (see James O'Bierne post).

- Will push some more updates soon.